### PR TITLE
✨ wtree add実行時に.worktreeディレクトリを自動作成

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,18 @@ fn add_worktree(branch: &str, custom_path: Option<String>) -> Result<()> {
 
     info!("Creating worktree at: {}", path.display());
 
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+            println!(
+                "{}",
+                format!("✓ Created directory: {}", parent.display()).green()
+            );
+        }
+    }
+
     // Check if branch exists
     let branch_exists = repo.find_branch(branch, git2::BranchType::Local).is_ok();
     


### PR DESCRIPTION
## 概要
`wtree add` コマンド実行時に、.worktreeディレクトリが存在しない場合は自動的に作成する機能を追加しました。

## 変更内容
- `add_worktree` 関数にディレクトリ存在確認処理を追加
- 親ディレクトリが存在しない場合は `fs::create_dir_all` で自動作成
- ディレクトリを作成した場合はユーザーに通知メッセージを表示

## 動作
1. `wtree add` コマンド実行時、ワークツリーのパスが決定される
2. 親ディレクトリ（通常は `.worktree`）の存在を確認
3. 存在しない場合は自動的に作成し、作成したことをユーザーに通知
4. その後、通常通りgit worktreeの作成処理を実行

## テスト
- [x] 手動での動作確認
- [ ] ユニットテストの追加
- [ ] ドキュメントの更新

## その他
この変更により、初回実行時でもエラーなくワークツリーを作成できるようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)