### PR TITLE
✨ goコマンドのシェル統合機能とgorootサブコマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,45 @@ git wtree go new-feature
 - Displays cd command for navigation
 - Shows available worktrees if target not found
 
+#### Shell Integration
+
+To actually change directories with `git wtree go`, you need to set up shell integration:
+
+**For Bash:**
+```bash
+# Add to your ~/.bashrc
+source /path/to/git-wtree/shell/git-wtree.bash
+
+# Then use either:
+git-wtree-go feature-branch
+# or the alias:
+wtgo feature-branch
+```
+
+**For Zsh:**
+```bash
+# Add to your ~/.zshrc
+source /path/to/git-wtree/shell/git-wtree.zsh
+
+# Then use either:
+git-wtree-go feature-branch
+# or the alias:
+wtgo feature-branch
+```
+
+**For Fish:**
+```fish
+# Add to your ~/.config/fish/config.fish
+source /path/to/git-wtree/shell/git-wtree.fish
+
+# Then use either:
+git-wtree-go feature-branch
+# or the alias:
+wtgo feature-branch
+```
+
+These shell functions use the `--print-path` flag to get the worktree path and change to it automatically.
+
 ### 4. **Remove worktree (`remove`, `rm`)**
 ```bash
 git wtree remove old-feature

--- a/completions/_git-wtree
+++ b/completions/_git-wtree
@@ -1,0 +1,81 @@
+#compdef git-wtree
+
+# Zsh completion for git-wtree
+
+# Helper function to list git branches
+_git_wtree_branches() {
+    local branches
+    branches=(${(f)"$(git branch --format='%(refname:short)' 2>/dev/null)"})
+    branches+=(${(f)"$(git branch -r --format='%(refname:short)' 2>/dev/null | sed 's|^origin/||')"})
+    _describe 'branch' branches
+}
+
+# Helper function to list worktrees
+_git_wtree_worktrees() {
+    local worktrees
+    worktrees=("main")
+    worktrees+=(${(f)"$(git worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //' | xargs -I {} basename {})"})
+    _describe 'worktree' worktrees
+}
+
+# Main completion function
+_git_wtree() {
+    local context state line
+    typeset -A opt_args
+
+    # Define subcommands
+    local -a subcommands
+    subcommands=(
+        'add:Create a new worktree'
+        'list:List all worktrees'
+        'ls:List all worktrees (alias)'
+        'go:Show navigation guide to a worktree'
+        'goroot:Navigate to git repository root'
+        'remove:Remove a worktree'
+        'rm:Remove a worktree (alias)'
+        'status:Show status of all worktrees'
+        'clean:Clean up missing worktrees'
+    )
+
+    # First level completion (subcommands)
+    _arguments -C \
+        '1: :->subcommand' \
+        '*:: :->args'
+
+    case $state in
+        subcommand)
+            _describe 'git-wtree subcommand' subcommands
+            ;;
+        args)
+            case $line[1] in
+                add)
+                    _arguments \
+                        '1:branch:_git_wtree_branches' \
+                        '2:path:_directories'
+                    ;;
+                go)
+                    _arguments \
+                        '--print-path[Print only the worktree path]' \
+                        '1:worktree:_git_wtree_worktrees'
+                    ;;
+                remove|rm)
+                    _arguments \
+                        '1:worktree:_git_wtree_worktrees'
+                    ;;
+                goroot)
+                    _arguments \
+                        '--print-path[Print only the root path]'
+                    ;;
+                *)
+                    # No additional arguments for other subcommands
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+# Register the completion
+_git_wtree "$@"
+
+# Also handle 'git wtree' (when used as a git subcommand)
+compdef _git_wtree git-wtree

--- a/completions/git-wtree.bash
+++ b/completions/git-wtree.bash
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Bash completion for git-wtree
+
+# Helper function to list git branches
+_git_wtree_branches() {
+    # List local branches
+    git branch --format='%(refname:short)' 2>/dev/null
+    # List remote branches (optional, removing origin/ prefix)
+    git branch -r --format='%(refname:short)' 2>/dev/null | sed 's|^origin/||'
+}
+
+# Helper function to list worktrees
+_git_wtree_worktrees() {
+    # First, add "main" for the main worktree
+    echo "main"
+    
+    # Then list other worktrees by parsing git worktree list output
+    git worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //' | while read -r path; do
+        # Extract the last component of the path as the worktree name
+        basename "$path"
+    done
+}
+
+# Main completion function
+_git_wtree() {
+    local cur prev words cword
+    _init_completion || return
+
+    local subcommands="add list ls go goroot remove rm status clean"
+    
+    # If we're on the first argument (subcommand)
+    if [[ $cword -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
+        return
+    fi
+    
+    # Get the subcommand
+    local subcmd="${words[1]}"
+    
+    case "$subcmd" in
+        add)
+            if [[ $cword -eq 2 ]]; then
+                # Complete branch names for the first argument
+                COMPREPLY=( $(compgen -W "$(_git_wtree_branches)" -- "$cur") )
+            elif [[ $cword -eq 3 ]]; then
+                # Complete file paths for the second argument
+                _filedir -d
+            fi
+            ;;
+        go)
+            if [[ $cword -eq 2 ]]; then
+                # Complete worktree names
+                COMPREPLY=( $(compgen -W "$(_git_wtree_worktrees)" -- "$cur") )
+            elif [[ $cword -eq 3 ]] && [[ "$prev" == "--print-path" ]]; then
+                # Complete worktree names after --print-path
+                COMPREPLY=( $(compgen -W "$(_git_wtree_worktrees)" -- "$cur") )
+            elif [[ $cword -eq 3 ]]; then
+                # Complete --print-path option if not already present
+                COMPREPLY=( $(compgen -W "--print-path" -- "$cur") )
+            fi
+            ;;
+        remove|rm)
+            if [[ $cword -eq 2 ]]; then
+                # Complete worktree names
+                COMPREPLY=( $(compgen -W "$(_git_wtree_worktrees)" -- "$cur") )
+            fi
+            ;;
+        goroot)
+            if [[ $cword -eq 2 ]]; then
+                # Complete --print-path option
+                COMPREPLY=( $(compgen -W "--print-path" -- "$cur") )
+            fi
+            ;;
+        *)
+            # No completion for other subcommands
+            ;;
+    esac
+}
+
+# Register the completion for git-wtree
+complete -F _git_wtree git-wtree
+
+# Also register for 'git wtree' (when used as a git subcommand)
+_git_wtree_git() {
+    # Skip 'git' and pass to _git_wtree
+    local words=("git-wtree" "${COMP_WORDS[@]:2}")
+    local cword=$((COMP_CWORD - 1))
+    COMP_WORDS=("${words[@]}")
+    COMP_CWORD=$cword
+    _git_wtree
+}
+
+# Check if git completion is loaded and register our handler
+if declare -F __git_complete >/dev/null 2>&1; then
+    __git_complete git-wtree _git_wtree_git
+fi

--- a/completions/git-wtree.fish
+++ b/completions/git-wtree.fish
@@ -64,6 +64,7 @@ complete -c git-wtree -n __fish_git_wtree_needs_command -a add -d "Create a new 
 complete -c git-wtree -n __fish_git_wtree_needs_command -a list -d "List all worktrees"
 complete -c git-wtree -n __fish_git_wtree_needs_command -a ls -d "List all worktrees (alias)"
 complete -c git-wtree -n __fish_git_wtree_needs_command -a go -d "Show navigation guide to a worktree"
+complete -c git-wtree -n __fish_git_wtree_needs_command -a goroot -d "Navigate to git repository root"
 complete -c git-wtree -n __fish_git_wtree_needs_command -a remove -d "Remove a worktree"
 complete -c git-wtree -n __fish_git_wtree_needs_command -a rm -d "Remove a worktree (alias)"
 complete -c git-wtree -n __fish_git_wtree_needs_command -a status -d "Show status of all worktrees"
@@ -95,6 +96,10 @@ complete -c git-wtree -n __fish_git_wtree_add_needs_path -F -d "Worktree path"
 
 # Completions for 'go' subcommand
 complete -c git-wtree -n "__fish_git_wtree_using_command go" -a "(__fish_git_wtree_worktrees)" -d "Worktree name"
+complete -c git-wtree -n "__fish_git_wtree_using_command go" -l print-path -d "Print only the worktree path"
+
+# Completions for 'goroot' subcommand
+complete -c git-wtree -n "__fish_git_wtree_using_command goroot" -l print-path -d "Print only the root path"
 
 # Completions for 'remove' and 'rm' subcommands
 complete -c git-wtree -n "__fish_git_wtree_using_command remove" -a "(__fish_git_wtree_worktrees)" -d "Worktree name"

--- a/shell/git-wtree.bash
+++ b/shell/git-wtree.bash
@@ -26,5 +26,22 @@ git-wtree-go() {
     fi
 }
 
-# Optional: Create an alias for convenience
+# git-wtree goroot subcommand shell wrapper
+git-wtree-goroot() {
+    # Call git-wtree goroot with --print-path to get the directory
+    local dir
+    dir=$(git wtree goroot --print-path 2>/dev/null)
+    
+    if [ $? -eq 0 ] && [ -n "$dir" ]; then
+        cd "$dir" || return 1
+        echo "Changed to git root: $dir" >&2
+    else
+        # If --print-path failed, fall back to normal output
+        git wtree goroot
+        return 1
+    fi
+}
+
+# Optional: Create aliases for convenience
 alias wtgo='git-wtree-go'
+alias wtroot='git-wtree-goroot'

--- a/shell/git-wtree.bash
+++ b/shell/git-wtree.bash
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# git-wtree go subcommand shell wrapper for bash
+# This function enables directory navigation with 'git wtree go'
+# Source this file in your .bashrc: source /path/to/git-wtree.bash
+
+git-wtree-go() {
+    local target="$1"
+    
+    if [ -z "$target" ]; then
+        echo "Usage: git-wtree-go <worktree-name>" >&2
+        return 1
+    fi
+    
+    # Call git-wtree go with --print-path to get the directory
+    local dir
+    dir=$(git wtree go --print-path "$target" 2>/dev/null)
+    
+    if [ $? -eq 0 ] && [ -n "$dir" ]; then
+        cd "$dir" || return 1
+        echo "Changed to worktree: $dir" >&2
+    else
+        # If --print-path failed, fall back to normal output
+        git wtree go "$target"
+        return 1
+    fi
+}
+
+# Optional: Create an alias for convenience
+alias wtgo='git-wtree-go'

--- a/shell/git-wtree.fish
+++ b/shell/git-wtree.fish
@@ -1,0 +1,28 @@
+# git-wtree go subcommand shell wrapper for fish
+# This function enables directory navigation with 'git wtree go'
+# Source this file in your config.fish: source /path/to/git-wtree.fish
+
+function git-wtree-go
+    set -l target $argv[1]
+    
+    if test -z "$target"
+        echo "Usage: git-wtree-go <worktree-name>" >&2
+        return 1
+    end
+    
+    # Call git-wtree go with --print-path to get the directory
+    set -l dir (git wtree go --print-path "$target" 2>/dev/null)
+    
+    if test $status -eq 0; and test -n "$dir"
+        cd "$dir"
+        or return 1
+        echo "Changed to worktree: $dir" >&2
+    else
+        # If --print-path failed, fall back to normal output
+        git wtree go "$target"
+        return 1
+    end
+end
+
+# Optional: Create an alias for convenience
+alias wtgo='git-wtree-go'

--- a/shell/git-wtree.fish
+++ b/shell/git-wtree.fish
@@ -24,5 +24,22 @@ function git-wtree-go
     end
 end
 
-# Optional: Create an alias for convenience
+# git-wtree goroot subcommand shell wrapper
+function git-wtree-goroot
+    # Call git-wtree goroot with --print-path to get the directory
+    set -l dir (git wtree goroot --print-path 2>/dev/null)
+    
+    if test $status -eq 0; and test -n "$dir"
+        cd "$dir"
+        or return 1
+        echo "Changed to git root: $dir" >&2
+    else
+        # If --print-path failed, fall back to normal output
+        git wtree goroot
+        return 1
+    end
+end
+
+# Optional: Create aliases for convenience
 alias wtgo='git-wtree-go'
+alias wtroot='git-wtree-goroot'

--- a/shell/git-wtree.zsh
+++ b/shell/git-wtree.zsh
@@ -1,0 +1,30 @@
+#!/bin/zsh
+
+# git-wtree go subcommand shell wrapper for zsh
+# This function enables directory navigation with 'git wtree go'
+# Source this file in your .zshrc: source /path/to/git-wtree.zsh
+
+git-wtree-go() {
+    local target="$1"
+    
+    if [[ -z "$target" ]]; then
+        echo "Usage: git-wtree-go <worktree-name>" >&2
+        return 1
+    fi
+    
+    # Call git-wtree go with --print-path to get the directory
+    local dir
+    dir=$(git wtree go --print-path "$target" 2>/dev/null)
+    
+    if [[ $? -eq 0 ]] && [[ -n "$dir" ]]; then
+        cd "$dir" || return 1
+        echo "Changed to worktree: $dir" >&2
+    else
+        # If --print-path failed, fall back to normal output
+        git wtree go "$target"
+        return 1
+    fi
+}
+
+# Optional: Create an alias for convenience
+alias wtgo='git-wtree-go'

--- a/shell/git-wtree.zsh
+++ b/shell/git-wtree.zsh
@@ -26,5 +26,22 @@ git-wtree-go() {
     fi
 }
 
-# Optional: Create an alias for convenience
+# git-wtree goroot subcommand shell wrapper
+git-wtree-goroot() {
+    # Call git-wtree goroot with --print-path to get the directory
+    local dir
+    dir=$(git wtree goroot --print-path 2>/dev/null)
+    
+    if [[ $? -eq 0 ]] && [[ -n "$dir" ]]; then
+        cd "$dir" || return 1
+        echo "Changed to git root: $dir" >&2
+    else
+        # If --print-path failed, fall back to normal output
+        git wtree goroot
+        return 1
+    fi
+}
+
+# Optional: Create aliases for convenience
 alias wtgo='git-wtree-go'
+alias wtroot='git-wtree-goroot'

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,9 @@ enum Commands {
     Go {
         /// Worktree name or branch name
         name: String,
+        /// Print only the worktree path (for shell integration)
+        #[arg(long)]
+        print_path: bool,
     },
     /// Remove a worktree
     #[command(alias = "rm")]
@@ -105,7 +108,7 @@ fn main() -> Result<()> {
     match cli.command {
         Commands::Add { branch, path } => add_worktree(&branch, path),
         Commands::List => list_worktrees(),
-        Commands::Go { name } => go_to_worktree(&name),
+        Commands::Go { name, print_path } => go_to_worktree(&name, print_path),
         Commands::Remove { name } => remove_worktree(&name),
         Commands::Status => show_status(),
         Commands::Clean => clean_worktrees(),
@@ -247,7 +250,7 @@ fn list_worktrees() -> Result<()> {
     Ok(())
 }
 
-fn go_to_worktree(name: &str) -> Result<()> {
+fn go_to_worktree(name: &str, print_path: bool) -> Result<()> {
     let repo = Repository::open_from_env()
         .context("Not in a git repository")?;
     
@@ -292,12 +295,22 @@ fn go_to_worktree(name: &str) -> Result<()> {
     }
     
     if let Some(path) = found_path {
-        println!("{}", "To navigate to this worktree, run:".green());
-        println!("  cd {}", path.display());
+        if print_path {
+            // Print only the path for shell integration
+            println!("{}", path.display());
+        } else {
+            println!("{}", "To navigate to this worktree, run:".green());
+            println!("  cd {}", path.display());
+        }
     } else {
-        println!("{}", format!("Worktree '{}' not found", name).red());
-        println!("\nAvailable worktrees:");
-        list_worktrees()?;
+        if print_path {
+            // When using --print-path, return with an error code but no output
+            std::process::exit(1);
+        } else {
+            println!("{}", format!("Worktree '{}' not found", name).red());
+            println!("\nAvailable worktrees:");
+            list_worktrees()?;
+        }
     }
     
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,13 @@ enum Commands {
     Status,
     /// Clean up missing worktrees
     Clean,
+    /// Navigate to git repository root
+    #[command(name = "goroot")]
+    GoRoot {
+        /// Print only the root path (for shell integration)
+        #[arg(long)]
+        print_path: bool,
+    },
 }
 
 fn get_help_footer() -> &'static str {
@@ -112,6 +119,7 @@ fn main() -> Result<()> {
         Commands::Remove { name } => remove_worktree(&name),
         Commands::Status => show_status(),
         Commands::Clean => clean_worktrees(),
+        Commands::GoRoot { print_path } => go_to_root(print_path),
     }
 }
 
@@ -311,6 +319,24 @@ fn go_to_worktree(name: &str, print_path: bool) -> Result<()> {
             println!("\nAvailable worktrees:");
             list_worktrees()?;
         }
+    }
+    
+    Ok(())
+}
+
+fn go_to_root(print_path: bool) -> Result<()> {
+    let repo = Repository::open_from_env()
+        .context("Not in a git repository")?;
+    
+    // Get the root directory of the git repository
+    let root_path = find_git_root(&repo)?;
+    
+    if print_path {
+        // Print only the path for shell integration
+        println!("{}", root_path.display());
+    } else {
+        println!("{}", "To navigate to the git repository root, run:".green());
+        println!("  cd {}", root_path.display());
     }
     
     Ok(())


### PR DESCRIPTION
## 概要
`git wtree go`コマンドで実際にディレクトリを移動できるシェル統合機能と、Gitリポジトリのルートに移動する`goroot`サブコマンドを追加しました。

## 変更内容
- `--print-path`フラグを`go`サブコマンドに追加し、パスのみを出力できるように変更
- 各シェル（bash, zsh, fish）用のラッパー関数を実装
- `goroot`サブコマンドを新規追加（Gitリポジトリのルートディレクトリに移動）
- bash/zsh用の補完スクリプトを新規作成
- 既存のfish補完を拡張し、`go`と`goroot`の補完を強化

## 主な機能
### シェル統合
```bash
# ~/.bashrc, ~/.zshrc, ~/.config/fish/config.fish に追記
source /path/to/git-wtree/shell/git-wtree.[bash|zsh|fish]

# 使用例
wtgo feature-branch    # worktreeに移動
wtroot                 # gitリポジトリのルートに移動
```

### 補完機能
- **Bash**: `completions/git-wtree.bash`
- **Zsh**: `completions/_git-wtree`
- **Fish**: `completions/git-wtree.fish`（更新）

## コミット
- ✨ git wtree goコマンドのシェル統合機能を追加
- ✨ goコマンドの補完とgorootサブコマンドを追加

## テスト
- [x] 手動での動作確認
- [x] 各シェルでの補完動作確認
- [ ] ドキュメントの更新

🤖 Generated with [Claude Code](https://claude.ai/code)